### PR TITLE
Add the missing composer-cli to package.json

### DIFF
--- a/packages/getting-started/package.json
+++ b/packages/getting-started/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "composer-admin": "~0.4.1-0",
     "composer-client": "~0.4.1-0",
+    "composer-cli": "~0.4.1-0",
     "digitalproperty-network": "latest",
     "cli-table": "^0.3.1",
     "config": "^1.24.0",


### PR DESCRIPTION
Hello "fabric-composer"s,

I'm pretty new to this project. As a matter of fact, saw it yesterday for the first time.
I have just downloaded and tried it locally, and I believe that we may need to add an extra dependency to the package.json. Though I may be wrong.

Please could you kindly take a look?

Thanks, Jonathan