### PR TITLE
fix(scripts): getting started fails if path has spaces

### DIFF
--- a/packages/getting-started/scripts/download-hyperledger.sh
+++ b/packages/getting-started/scripts/download-hyperledger.sh
@@ -7,7 +7,7 @@ set -ev
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 # Shut down the Docker containers that might be currently running.
-cd ${DIR}/scripts
+cd "${DIR}"/scripts
 docker-compose kill && docker-compose down
 
 # TODO change this to alter the default profile which is, by convention, a local running hyperledger fabric

--- a/packages/getting-started/scripts/setup.sh
+++ b/packages/getting-started/scripts/setup.sh
@@ -11,7 +11,7 @@ rm -rf ~/.composer-connection-profiles/*
 rm -rf ~/.composer-credentials/*
 
 # Shut down the Docker containers that might be currently running.
-cd ${DIR}/scripts
+cd "${DIR}"/scripts
 docker-compose kill && docker-compose down
 
 
@@ -26,7 +26,7 @@ docker-compose build
 docker-compose up -d
 
 #
-cd ${DIR}
+cd "${DIR}"
 
 # Wait for the Hyperledger Fabric to start.#
 while ! nc localhost 7051 </dev/null; do sleep 1; done

--- a/packages/getting-started/scripts/start-hyperledger.sh
+++ b/packages/getting-started/scripts/start-hyperledger.sh
@@ -7,7 +7,7 @@ set -ev
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 #
-cd ${DIR}/scripts
+cd "${DIR}"/scripts
 
 # Start up the Hyperledger Fabric
 docker-compose up -d --build

--- a/packages/getting-started/scripts/stop-hyperledger.sh
+++ b/packages/getting-started/scripts/stop-hyperledger.sh
@@ -7,5 +7,5 @@ set -ev
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 # Shut down the Docker containers that might be currently running.
-cd ${DIR}/scripts
+cd "${DIR}"/scripts
 docker-compose stop

--- a/packages/getting-started/scripts/teardown.sh
+++ b/packages/getting-started/scripts/teardown.sh
@@ -7,7 +7,7 @@ set -ev
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 # Shut down the Docker containers for the system tests.
-cd ${DIR}/scripts
+cd "${DIR}"/scripts
 docker-compose kill && docker-compose down
 
 # remove the local state


### PR DESCRIPTION
 If you are working in a directory path that contained spaces, the getting started samples fail to work

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>