### PR TITLE
fix(scripts): ubuntu prereq not using sudo

### DIFF
--- a/packages/getting-started/scripts/prereqs-ubuntu.sh
+++ b/packages/getting-started/scripts/prereqs-ubuntu.sh
@@ -15,8 +15,8 @@ if [[ $1 == "docker" ]]; then
 	# You will need to have logged out and logged back in order after running the first script for this script to work!
 
 	# Install docker compose
-	curl -L "https://github.com/docker/compose/releases/download/1.10.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-	chmod +x /usr/local/bin/docker-compose
+	sudo curl -L "https://github.com/docker/compose/releases/download/1.10.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+	sudo chmod +x /usr/local/bin/docker-compose
 
 	echo "Finished install"
 else


### PR DESCRIPTION
changed the prereq script for the docker section to use sudo

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>