### PR TITLE
Fix package dependency versions

### DIFF
--- a/packages/digitalproperty-app/package.json
+++ b/packages/digitalproperty-app/package.json
@@ -35,10 +35,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "cli-table": "^0.3.1",
-    "composer-cli":"^0.9.0-0",
-    "composer-client":"^0.9.0-0",
+    "composer-cli":"^0.10.0",
+    "composer-client":"^0.10.0",
     "config": "^1.24.0",
-    "digitalproperty-network": "^0.1.0-0",
+    "digitalproperty-network": "^0.1.2",
     "jsonfile": "^2.4.0",
     "lodash": "^4.17.4",
     "prettyjson": "^1.2.1",
@@ -50,7 +50,6 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "chai-things": "^0.2.0",
-    "composer-connector-embedded": "^0.9.0-0",
     "mocha": "^3.2.0",
     "sinon": "^1.17.6",
     "sinon-as-promised": "^4.0.2"


### PR DESCRIPTION
Fix for: Deployed chain-code (0.9.2) is incompatible with client (0.10.0) #1645

`composer-connector-embedded` isn't used, no idea why it is in here!