### PR TITLE
Properly explain what is "getting-started" in main README and correct 'info.js' instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,17 @@
 
 The repository contains sample applications written against the [Hyperledger Composer](https://hyperledger.github.io/composer/)
 
-Currently this contains the code and scripts for the ['DigitalProperty-App'](./packages/digitalproperty-app/README.md) tutorial.
+Currently this contains the code and scripts for the ['DigitalProperty-App'](./packages/digitalproperty-app/README.md) tutorial - see the README in that directory for instructions on how to install.
+
+To install this repo and find out more about the sample applications, run (from this directory):
+```
+
+npm install
+node info.js
+
+```
+
 
 We welcome Pull Requests for new applications - please see the [contributing notes](https://github.com/hyperledger/composer/blob/master/CONTRIBUTING.md).
 
-*IMPORTANT NOTE*  The Getting Started application is the main route for people to get started with Hyperledger Composer - please exercise care when changing it!
+*IMPORTANT NOTE*  The Digital Property ("getting-started") sample CLI-based application is the main route for people to get started with Hyperledger Composer - please exercise care when changing it!

--- a/packages/digitalproperty-app/README.md
+++ b/packages/digitalproperty-app/README.md
@@ -94,7 +94,7 @@ This diagram should to clarify the order in which the scripts can be run.
 ![](CmdOrder.png).
 
 
-# Step 2: Getting the Hyperledger Composer sample application (digital property sample) up and running
+# Step 2: Getting the Hyperledger Composer sample application (the Digital Property CLI sample application) up and running
 
 0. Make sure you've started Fabric as in Step 1 above. For example, If this is your first time for example
 
@@ -113,8 +113,7 @@ $ cd composer-sample-applications
 $
 ```
 
-To see a summary of all the sample applications, there's a simple command that will show summary details of the applications
-A useful information node.js script has been created to show the available sample applications
+OPTIONAL: To see a summary of all the sample applications, there's a simple command that will show summary details of the sample applications available in this repository. A useful information node.js script has been created to show the available sample applications - note you will need to run `npm install` from the current directory (takes about 5-10 mins) before running this command.
 ```
 $ node ~/github/composer-sample-applications/info.js
 ```


### PR DESCRIPTION
Explain that Digital Property app is the 'getting-started' app and correctly explain the instruction for 'info.js' as being in the 'main sample-applications' README file, where previously it was only explained deep in the README for digitalproperty-app. Still described there too - but as an OPTIONAL step, if someone had come 'straight' to that sample app directory, directly and was following the instructions on cloning the sample-applications repository.

This PR relates to https://github.com/hyperledger/composer-sample-applications/issues/72 and also https://github.com/hyperledger/composer-sample-applications/issues/78 following 'tidy-up' of 0.6 instructions.