### PR TITLE
Bump to v0.0.3

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
-  "lerna": "2.0.0-rc.4",
+  "lerna": "2.0.0",
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.2"
+  "version": "0.0.3"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "author": "Hyperledger Composer",
   "license": "Apache-2.0",
@@ -18,7 +18,9 @@
     "prettyjson": "^1.2.1"
   },
   "devDependencies": {
-    "lerna": "^2.0.0"
+    "colors": "^1.1.2",
+    "lerna": "^2.0.0",
+    "semver": "^5.4.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "colors": "^1.1.2",
     "lerna": "^2.0.0",
+    "moment": "^2.18.1",
     "semver": "^5.4.1"
   },
   "repository": {

--- a/packages/digitalproperty-app/package.json
+++ b/packages/digitalproperty-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalproperty-app",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Hyperledger Composer - Digital Property console application",
   "bin": {
     "digitalproperty": "cli.js"

--- a/packages/vehicle-lifecycle-car-builder/package.json
+++ b/packages/vehicle-lifecycle-car-builder/package.json
@@ -39,7 +39,7 @@
     "typescript": "~2.2.1",
     "zone.js": "^0.8.4"
   },
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Vehicle Lifecycle - A mobile application for the customers view",
   "license": "Apache-2.0"
 }

--- a/packages/vehicle-lifecycle-manufacturing/package.json
+++ b/packages/vehicle-lifecycle-manufacturing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vehicle-lifecycle-manufacturer",
   "private": true,
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Vehicle Lifecycle - A manufacturers view",
   "main": "index.js",
   "scripts": {

--- a/packages/vehicle-lifecycle-vda/package.json
+++ b/packages/vehicle-lifecycle-vda/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vehicle-lifecycle-vda",
   "private": true,
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Vehicle Lifecycle - A regulators view",
   "main": "index.js",
   "scripts": {

--- a/packages/vehicle-lifecycle/package.json
+++ b/packages/vehicle-lifecycle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vehicle-lifecycle",
   "private": true,
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "## Installation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This should have been automatically ages ago but it looks like the `package.json` does not contain the correct `devDependencies` for running the version management scripts.

Needed to cut a release for:
Node Red Nodes and Historian API Out of Date #90