### PR TITLE
Node-RED flows do not work due to use of PeerAdmin

### DIFF
--- a/packages/vehicle-lifecycle/installers/hlfv1/flows.json
+++ b/packages/vehicle-lifecycle/installers/hlfv1/flows.json
@@ -43,8 +43,8 @@
         "z": "",
         "connectionProfile": "hlfv1",
         "businessNetworkIdentifier": "vehicle-lifecycle-network",
-        "userID": "PeerAdmin",
-        "userSecret": "whatever"
+        "userID": "admin",
+        "userSecret": "randomString"
     },
     {
         "id": "22d020e3.5e7388",


### PR DESCRIPTION
https://github.com/hyperledger/composer/issues/670

The Node-RED flows are configured to use PeerAdmin, which is not bound to a business network administrator, so the Node-RED flows do not work - they get connection errors! 🐧 