### PR TITLE
Fix issue with shared credentials being read only

### DIFF
--- a/packages/vehicle-lifecycle/installers/hlfv1/install.sh.in
+++ b/packages/vehicle-lifecycle/installers/hlfv1/install.sh.in
@@ -148,6 +148,13 @@ docker run \
   hyperledger/composer-cli:{{ENV}} \
   composer transaction submit -p hlfv1 -n vehicle-lifecycle-network -i admin -s adminpw -d '{"$class": "org.acme.vehicle.lifecycle.SetupDemo"}'
 
+# correct the admin credential permissions
+docker run \
+  --rm \
+  -v $(pwd)/.composer-credentials:/home/composer/.composer-credentials \
+  hyperledger/composer-cli:{{ENV}} \
+  find /home/composer/.composer-credentials -name "*" -exec chmod 777 {} \;
+
 # Start the REST server.
 docker run \
   -d \


### PR DESCRIPTION
This fixes
https://github.com/hyperledger/composer-sample-applications/issues/99
by waiting for the admin credentials to be created then using the same docker image go in an change the permissions of the admin files such that everyone has r/w access.

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>