### PR TITLE
Allow any user to be able to access card store

### DIFF
--- a/packages/vehicle-lifecycle/installers/hlfv1/install.sh.in
+++ b/packages/vehicle-lifecycle/installers/hlfv1/install.sh.in
@@ -72,10 +72,12 @@ stop
 # create a card store on the local file system to be shared by the demo
 rm -fr $(pwd)/.vld-card-store  
 mkdir $(pwd)/.vld-card-store
+chmod 777 $(pwd)/.vld-card-store
 
 # Create the environment variables with the connection profile in.
 rm -fr $(pwd)/vldstage
 mkdir $(pwd)/vldstage
+chmod 777 $(pwd)/vldstage
 echo '{
     "name": "hlfv1",
     "description": "Hyperledger Fabric v1.0",


### PR DESCRIPTION
As the runner of the vld demo creates the card store, we need to ensure no matter what user they are, the containers still are able to access the store

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>