### PR TITLE
Add pm2 to demo, fix manufacturing package name

### DIFF
--- a/packages/vehicle-lifecycle-car-builder/Dockerfile
+++ b/packages/vehicle-lifecycle-car-builder/Dockerfile
@@ -1,11 +1,12 @@
-FROM node:6-alpine
+FROM node:8-alpine
 ENV NPM_CONFIG_LOGLEVEL warn
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY package.json /usr/src/app/
-RUN npm install --production  && \
-    npm cache clean
+RUN npm install --production && \
+    npm install --production -g pm2 && \
+    npm cache clean --force
 COPY app.js /usr/src/app/
 COPY www /usr/src/app/www
 EXPOSE 6001
-CMD [ "npm", "start" ]
+CMD [ "pm2-docker", "npm", "--", "start" ]

--- a/packages/vehicle-lifecycle-manufacturing/Dockerfile
+++ b/packages/vehicle-lifecycle-manufacturing/Dockerfile
@@ -1,16 +1,16 @@
-FROM node:6-alpine
+FROM node:8-alpine
 ENV NPM_CONFIG_LOGLEVEL warn
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY package.json bower.json .bowerrc /usr/src/app/
 RUN apk add --no-cache git && \
-    npm install --production -g bower && \
+    npm install --production -g bower pm2 && \
     npm install --production  && \
     bower install && \
     bower cache clean && \
     npm uninstall -g bower && \
-    npm cache clean && \
+    npm cache clean --force && \
     apk del git
 COPY . /usr/src/app/
 EXPOSE 6001
-CMD [ "npm", "start" ]
+CMD [ "pm2-docker", "npm", "--", "start" ]

--- a/packages/vehicle-lifecycle-manufacturing/package.json
+++ b/packages/vehicle-lifecycle-manufacturing/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vehicle-lifecycle-manufacturer",
+  "name": "vehicle-lifecycle-manufacturing",
   "private": true,
   "version": "0.0.5",
   "description": "Vehicle Lifecycle - A manufacturers view",

--- a/packages/vehicle-lifecycle-vda/Dockerfile
+++ b/packages/vehicle-lifecycle-vda/Dockerfile
@@ -1,16 +1,16 @@
-FROM node:6-alpine
+FROM node:8-alpine
 ENV NPM_CONFIG_LOGLEVEL warn
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY package.json bower.json .bowerrc /usr/src/app/
 RUN apk add --no-cache git && \
-    npm install --production -g bower && \
+    npm install --production -g bower pm2 && \
     npm install --production  && \
     bower install && \
     bower cache clean && \
     npm uninstall -g bower && \
-    npm cache clean && \
+    npm cache clean --force && \
     apk del git
 COPY . /usr/src/app/
 EXPOSE 6001
-CMD [ "npm", "start" ]
+CMD [ "pm2-docker", "npm", "--", "start" ]


### PR DESCRIPTION
The Docker images for the vehicle lifecycle demo can crash sometimes, but because they don't use pm2 the images go into the stopped state. This means that the user needs to manually restart them to continue using the demo.

- Install pm2 and use `pm2-docker` to run the applications
- Upgrade the applications to Node.js 8
- Fix the name of the manufacturing package