### PR TITLE
Display problems on manufacturer and VDA screens

### DIFF
--- a/packages/vehicle-manufacture-manufacturing/client/app/views/dashboard/dashboard.html
+++ b/packages/vehicle-manufacture-manufacturing/client/app/views/dashboard/dashboard.html
@@ -132,8 +132,6 @@
           </div>
     </div>
   </div>
-</div>
-</div>
   <div>
     <div class="bc-man-overview">
       <h5>
@@ -142,7 +140,7 @@
         <button class="btn fade">Weekly</button>
         <button class="btn fade">Monthly</button>
       </h5>
-
+  
       <div class="graphs">
         <img src="/manufacturer/assets/images/Graph 1.svg" alt="Cars Produced">
         <img src="/manufacturer/assets/images/Graph 2.svg" alt="Queued Drills">

--- a/packages/vehicle-manufacture-manufacturing/client/app/views/dashboard/dashboard.less
+++ b/packages/vehicle-manufacture-manufacturing/client/app/views/dashboard/dashboard.less
@@ -4,9 +4,10 @@
   width: 100%;
   box-sizing: border-box;
   margin: 42px 52px;
+  display: flex;
+  flex-direction: column;
 
   h1 {
-    margin: 0 0 60px 0;
     display: flex;
     justify-content: space-between;
 

--- a/packages/vehicle-manufacture-vda/client/app/directives/blockchain-view/blockchain-view.directive.js
+++ b/packages/vehicle-manufacture-vda/client/app/directives/blockchain-view/blockchain-view.directive.js
@@ -1,6 +1,6 @@
 angular.module('bc-vda')
 
-.directive('bcView', [function () {
+.directive('bcView', ['$window', function ($window) {
   return {
     restrict: 'E',
     replace: true,
@@ -24,6 +24,21 @@ angular.module('bc-vda')
         height: 145,
         padding: 30
       };
+
+      function debouncer( func , timeout ) {
+        var timeoutID , timeout = timeout || 200;
+        return function () {
+           var scope = this , args = arguments;
+           clearTimeout( timeoutID );
+           timeoutID = setTimeout( function () {
+               func.apply( scope , Array.prototype.slice.call( args ) );
+           } , timeout );
+        }
+     }
+
+      angular.element($window).bind('resize', debouncer (function(){
+        updateChart();
+      }));
 
       function updateChart() {
         // calculate width of chain


### PR DESCRIPTION
Fix moves graphs back to bottom of page rather than right hand side which occurred after previous changes. Fix also ensures that the VDA screen chain aligns left after resize. 