### PR TITLE
Vehicle Manufacture Demo not building.

### DIFF
--- a/packages/vehicle-manufacture/README.md
+++ b/packages/vehicle-manufacture/README.md
@@ -8,6 +8,8 @@ This command creates a `install.sh` script (inside of installers/hlfv1) containi
 
 2. Run `cat installers/hlfv1/install.sh | bash` from within the `vehicle-manufacture` package
 
+*To run the demo with Fabric version 1.1.0: set the DEMO\_FABRIC\_VERSION env variable to hlfv11 using `export DEMO_FABRIC_VERSION=hlfv11`. Then run `./build.sh` and `cat installers/hlfv11/install.sh | bash`*
+
 This executes the script (and payload) starting up several Docker images for each vehicle-lifecycle demo element as well as setting up Hyperledger Fabric and Composer.
 Running this command will teardown any other running Docker images.
 

--- a/packages/vehicle-manufacture/installers/hlfv1/build.sh
+++ b/packages/vehicle-manufacture/installers/hlfv1/build.sh
@@ -20,7 +20,7 @@ npm install
 
 cd "${DIR}"
 cat install.sh.in | sed \
-    -e 's/{{COMPOSER-VERSION}}/latest/g' \
+    -e 's/{{COMPOSER-VERSION}}/0.16.5/g' \
     -e 's/{{VEHICLE-MANUFACTURE-VERSION}}/latest/g' \
     -e 's/{{NODE-RED-VERSION}}/latest/g' \
     > install.sh

--- a/packages/vehicle-manufacture/installers/hlfv11/build.sh
+++ b/packages/vehicle-manufacture/installers/hlfv11/build.sh
@@ -21,8 +21,8 @@ npm install vehicle-manufacture-network@~0.2.1 --no-save
 cd "${DIR}"
 cat install.sh.in | sed \
     -e 's/{{COMPOSER-VERSION}}/next/g' \
-    -e 's/{{VEHICLE-LIFECYCLE-VERSION}}/latest/g' \
-    -e 's/{{NODE-RED-VERSION}}/next/g' \
+    -e 's/{{VEHICLE-MANUFACTURE-VERSION}}/latest/g' \
+    -e 's/{{NODE-RED-VERSION}}/latest/g' \
     > install.sh
 echo "PAYLOAD:" >> install.sh
-tar czf - -C $DIR $ROOT/node_modules/vehicle-manufacture-network/dist -C $DIR flows.json fabric-dev-servers >> install.sh
+tar czf - -C $ROOT/node_modules/vehicle-manufacture-network/dist vehicle-manufacture-network.bna -C $DIR flows.json fabric-dev-servers >> install.sh


### PR DESCRIPTION
Vehicle Manufacture demo was not building for hlfv1 or hlvf11.
This fixes #126

The COMPOSER-VERSION in build.sh for hlfv1 was changed from 'latest'
to '0.16.5' to fix a compatibility issue.

The build.sh for hlfv11 had placeholder VEHICLE-LIFECYCLE-VERSION
replaced with VEHICLE-MANUFACTURE-VERSION.
The vehicle-manufacture-network.bna was added to the PAYLOAD of the
install.sh.
NODE-RED-VERSION set to 'latest'.

Added instructions to run the demo against hlfv11 to the README

Signed-off-by: Rob Miroballi <rmiroballi@gmail.com>